### PR TITLE
coa and flags

### DIFF
--- a/config/common/coat_of_arms.cwt
+++ b/config/common/coat_of_arms.cwt
@@ -1,5 +1,78 @@
 types = {
-    type[coat_of_arm] = {
+    ## type_key_filter <> template
+    type[coat_of_arms] = {
         path = "game/common/coat_of_arms/coat_of_arms"
+    }
+}
+
+coat_of_arms = {
+    pattern = scalar # can't get this to work -> filepath[game/gfx/coat_of_arms/patterns/]
+    ## cardinality = 1..6
+    enum[color_num] = scalar #enum[named_colors]
+    ## cardinality = 0..inf
+    colored_emblem = {
+        texture = scalar #filepath[game/gfx/coat_of_arms/colored_emblems/]
+        ## cardinality = 1..6
+        enum[color_num] = scalar #enum[named_colors]
+        ## cardinality = 1..6
+        enum[color_num] = enum[color_num]
+        ## cardinality = 0..inf
+        instance = {
+            scale = {
+                ## cardinality = 2..2
+                float
+            }
+            position = {
+                ## cardinality = 2..2
+                float
+            }
+            ## cardinality = 0..1
+            rotation = int
+        }
+    }
+    ## cardinality = 0..inf
+    textured_emblem = {
+        texture = scalar #filepath[game/gfx/coat_of_arms/textured_emblems/]
+        ## cardinality = 0..inf
+        instance = {
+            scale = {
+                ## cardinality = 2..2
+                float
+            }
+            position = {
+                ## cardinality = 2..2
+                float
+            }
+            ## cardinality = 0..1
+            rotation = int
+        }
+    }
+    ## cardinality = 0..inf
+    sub = {
+        parent = <coat_of_arms>
+        ## cardinality = 0..inf
+        instance = {
+            scale = {
+                ## cardinality = 2..2
+                float
+            }
+            position = {
+                ## cardinality = 2..2
+                float
+            }
+            ## cardinality = 0..1
+            rotation = int
+        }
+    }
+}
+
+enums = {
+    enum[color_num] = {
+        color1
+        color2
+        color3
+        color4
+        color5
+        color6
     }
 }

--- a/config/common/flag_definitions.cwt
+++ b/config/common/flag_definitions.cwt
@@ -1,6 +1,31 @@
-# TODO: More complicated than this
-# types = {
-#     type[flag_definition] = {
-#         path = "game/common/flag_definitions"
-#     }
-# }
+types = {
+    type[flag_definition] = {
+        path = "game/common/flag_definitions"
+        # technically the root, which is a country tag, should be the type, but this is easier
+        skip_root_key = any
+        name_field = "coa"
+    }
+}
+
+flag_definition = {
+    coa = <coat_of_arms>
+    ## cardinality = 0..1
+    subject_canton = <coat_of_arms>
+    ## cardinality = 0..1
+    coa_with_overlord_canton = <coat_of_arms>
+    ## cardinality = 0..1
+    allow_overlord_canton = bool
+    ## cardinality = 0..1
+    overlord_canton_offset = {
+        ## cardinality = 2..2
+        float
+    }
+    ## cardinality = 0..1
+    overlord_canton_scale = {
+        ## cardinality = 2..2
+        float
+    }
+    priority = int
+    ## cardinality = 0..1
+    trigger = single_alias_right[trigger_clause]
+}

--- a/config/common/named_colors.cwt
+++ b/config/common/named_colors.cwt
@@ -1,5 +1,23 @@
 types = {
     type[named_color] = {
+        skip_root_key = colors
         path = "game/common/named_colors"
     }
+}
+
+named_color = {
+
+}
+
+enums = {
+    complex_enum[named_colors] = {
+		path = "game/common/named_colors"
+        start_from_root = yes
+		name = {
+            colors = {
+                # "name = hsv360/hsv/rgb { values }" color format explicitly named in script (except once)
+                enum_name = scalar { }
+            }
+		}
+	}
 }


### PR DESCRIPTION
Two main difficulties:
1. Allowing/discounting `@variables` such as `@semy = 0.25` which are defined either for the file or for a single coa/flag definitions
2. Allowing for `@math` which can be used in either `@variables` or in instance values (scale/position), e.g. `@third = @[1/3]` or "scale = { 1.0 @[1/7*5] }"

Lesser issues:
Figure out filepath for coa image files
Figure out how to type or enum named colors