### PR TITLE
Mapped map gfx types

### DIFF
--- a/config/enums.cwt
+++ b/config/enums.cwt
@@ -856,6 +856,7 @@ enums = {
         state_mass_migration_pull
         mass_migration_pull
         player_country
+        interests
     }
     enum[map_mode_names] = {
         countries
@@ -885,6 +886,7 @@ enums = {
         goods
         market
         power_bloc
+        strategic_region
     }
     enum[map_mode_texture_mode] = {
         occupation
@@ -983,5 +985,43 @@ enums = {
         shopkeeper_owned
         bureaucrat_owned
         academic_owned
+    }
+
+    enum[army_diorama_battle_side] = {
+        none
+        attacker
+        defender
+        either
+    }
+
+    enum[front_graphic_type] = {
+        battle
+        after_battle
+        on_battle_ended
+    }
+
+    enum[fleet_diorama_group] = {
+        fleet
+        battle_side
+        blockade
+    }
+
+    enum[fleet_entity_modification_slot_type] = {
+        ship_mod_slot_armor
+        ship_mod_slot_guns
+        ship_mod_slot_propulsion
+        ship_mod_slot_range
+    }
+
+    enum[fleet_entity_hull_type] = {
+        wood
+        steel
+    }
+
+    enum[fleet_entity_weapon_type] = {
+        none
+        cannon
+        turret
+        torpedo
     }
 }

--- a/config/gfx/map/air_graphics.cwt
+++ b/config/gfx/map/air_graphics.cwt
@@ -1,0 +1,41 @@
+types = {
+    type[air_graphic] = {
+        path = "gfx/map/air_graphics"
+        path_extension = .txt
+    }
+}
+
+## replace_scope = { root = country this = country }
+air_graphic = {
+    ### Entities that could be used for this air type
+    entities = {
+        ## cardinality = 1..inf
+        scalar = {
+            ### Entity name from .asset files
+            name = <entity>
+
+            weight = single_alias_right[formula]
+
+            possible = single_alias_right[trigger_clause]
+        }
+    }
+
+    ### Trigger to determine if the entity is possible at all for country scope both 'region' and 'target_region'
+    possible = single_alias_right[trigger_clause]
+
+    ### Entity length is the length used for placing entities on the air route, default 3
+    ## cardinality = 0..1
+    entity_length = float
+
+    ### Speed is how fast the entity of this type is moving, default 0.5
+    ## cardinality = 0..1
+    speed = float
+
+    ### Max count is max amount of those air entities shown on the map, default 100
+    ## cardinality = 0..1
+    max_count = int
+
+    ### Air offset for entity, default 1.0
+    ## cardinality = 0..1
+    height = float
+}

--- a/config/gfx/map/army_dioramas.cwt
+++ b/config/gfx/map/army_dioramas.cwt
@@ -1,0 +1,76 @@
+types = {
+    type[army_diorama] = {
+        path = "gfx/map/army_dioramas"
+        path_extension = .txt
+    }
+}
+
+army_diorama = {
+
+    ### Unit composition is checked when picking a diorama for a certain province
+    ### The closer the composition of the army in the province corresponds to the percentage, the higher the chance of choosing this diorama
+    unit_composition = {
+        ## cardinality = 1..inf
+        <combat_unit_group> = int
+    }
+
+    required_unit_types = {
+        ## cardinality = 1..inf
+        <combat_unit_type>
+    }
+
+    ### Distance between the center of the diorama and the frontline
+    distance = int
+
+    ## cardinality = 0..1
+    basecamp = bool
+
+    ### If it can be used as a battle side for a battle diorama (values: none/attacker/defender/either)
+    battle_side = enum[army_diorama_battle_side]
+
+    ### Define all locators for the different assets
+    ## cardinality = 1..inf
+    locator = {
+        name = value_set[army_diorama_locator]
+
+        position = {
+            ## cardinality = 3..3
+            float
+        }
+
+        rotation = {
+            ## cardinality = 3..3
+            float
+        }
+
+        scale = float
+    }
+
+    ### Attach all the correct units to locators
+    ## cardinality = 1..inf
+    attach = {
+        locator = value[army_diorama_locator]
+
+        ## cardinality = 0..1
+        entity = <entity>
+
+        ## cardinality = 0..1
+        combat_unit_group = <combat_unit_group>
+
+        ## cardinality = 0..1
+        entity_group = value[front_entity_group]
+
+        ## cardinality = 0..1
+        can_be_defeated = bool
+
+        ## cardinality = 0..1
+        is_visible = single_alias_right[trigger_clause]
+
+        ## cardinality = 0..1
+        general = bool
+
+        ## cardinality = 0..1
+        ignore_terrain = bool
+    }
+
+}

--- a/config/gfx/map/borders/front_graphics.cwt
+++ b/config/gfx/map/borders/front_graphics.cwt
@@ -1,0 +1,38 @@
+types = {
+    type[front_graphic] = {
+        path = "gfx/map/borders/front_graphics"
+        path_extension = .txt
+    }
+}
+
+## replace_scope = { root = country this = country }
+front_graphic = {
+    ### "Type" will determine when the entity should show (battle is ongoin or battle is finished)
+    type = enum[front_graphic_type]
+
+    ### Trigger to determine if that type should be used for scoped country 'attacker' and it's "target" country
+    possible = single_alias_right[trigger_clause]
+
+    ### Scripted value to determine which type to pick for specified type for scoped country 'attacker' and it's "target" country
+    weight = single_alias_right[formula]
+
+    ## cardinality = 0..1
+    participant_entities = {
+        ## cardinality = 0..inf
+        scalar = {
+            ### Entity name from .asset files
+            name = <entity>
+
+            ### Trigger for country and 'target' - opposite country, 'front' current front, 'battle' battle
+            trigger = single_alias_right[trigger_clause]
+        }
+    }
+
+    ### Entities that could be used for this air type
+    environment_entity = {
+        ### Entity name from .asset files
+        name = <entity>
+
+        one_time_action = bool
+    }
+}

--- a/config/gfx/map/building_config.cwt
+++ b/config/gfx/map/building_config.cwt
@@ -1,0 +1,18 @@
+types = {
+    type[building_config] = {
+        path = "gfx/map/building_config"
+        path_extension = .txt
+    }
+}
+
+building_config = {
+    size = int
+
+    ## cardinality = 0..1
+    particles = {
+        ## cardinality = 0..inf
+        scalar = filepath[gfx/particles/,.particle2]
+    }
+
+    construction_entity = <entity>
+}

--- a/config/gfx/map/city_data/city_building_vfx.cwt
+++ b/config/gfx/map/city_data/city_building_vfx.cwt
@@ -1,0 +1,20 @@
+types = {
+    type[city_building_vfx] = {
+        path = "gfx/map/city_data/city_building_vfx"
+        path_extension = .txt
+    }
+}
+
+city_building_vfx = {
+    ### name of the particle type that attaches to a building with the locator
+    ### name can be found in .asset files in "gfx/models/buildings/", entity -> particles -> locator_x -> value (e.g. "locator_chimney" = "infrastructure/factory_smoke")
+    particle = filepath[gfx/particles/,.particle2]
+
+    ### maximum visible instances of the particle type; default = -1 - no limit
+    ## cardinality = 0..1
+    max_visible = int
+
+    ### maximum distance to the city which to show particles on; default = 0 - no limit
+    ## cardinality = 0..1
+    max_distance = int
+}

--- a/config/gfx/map/city_data/city_centerpiece.cwt
+++ b/config/gfx/map/city_data/city_centerpiece.cwt
@@ -1,0 +1,151 @@
+types = {
+    type[city_centerpiece] = {
+        path = "gfx/map/city_data/city_centerpiece"
+        path_extension = .txt
+        subtype[type] = {
+            city_type = enum[city_type]
+        }
+        subtype[city_type] = {
+            city_graphics_type = <city_type>
+        }
+    }
+}
+
+city_centerpiece = {
+    subtype[type] = {
+        ### [Mutually exclusive with 'city_graphics_type'] [Default = none] Which type of hub this centerpiece is picked for
+        city_type = enum[city_type]
+    }
+
+    subtype[city_type] = {
+        ### [Mutually exclusive with 'city_type'] [Can be repeated] Which city graphics type this centerpiece is applicable for
+        ## cardinality = 1..inf
+        city_graphics_type = <city_type>
+    }
+
+    ### [Default = always yes] Trigger to pick this centerpiece for the state region
+    ### Root - state region
+    ## cardinality = 0..1
+    ## replace_scope = { root = state_region this = state_region }
+    trigger = single_alias_right[trigger_clause]
+
+    ### [Default = 0] If there are multiple centerpieces suitable for the state region and city type, the one with the highest priority is picked
+    ## cardinality = 0..1
+    priority = int
+
+    ### [Default = no] Rebuild the centerpiece whenever a production method is changed in the state.
+    ### It's required for certain compositions that have triggers checking active production methods
+    ## cardinality = 0..1
+    should_update_on_pm_change = bool
+
+    ### [Can be repeated] Locators where the attachments will be located relative to the center point of the city
+    ## cardinality = 0..inf
+    locator = {
+        ### The name is used in 'attach' below
+        name = value_set[city_centerpiece_locator]
+
+        position = {
+            ## cardinality = 3..3
+            float
+        }
+
+        rotation = {
+            ## cardinality = 3..3
+            float
+        }
+
+        scale = float
+    }
+
+
+    ## cardinality = 0..1
+    composition_group = {
+        ### Which building types are calculated for this composition group.
+        ### It's required for compositions with 'levels' or 'ratios'
+        ## cardinality = 0..1
+        building_types = {
+            ## cardinality = 0..inf
+            <building>
+        }
+
+        ### Level thresholds which are used to transform building level into visual level
+        ### which is then used in composition 'levels',i.e. 'levels = { 1 4 9 }' defines 3 level intervals { {1-3} {4-8} {9+} }
+        ## cardinality = 0..1
+        levels = {
+            ## cardinality = 0..inf
+            int
+        }
+
+        ### [Can be repeated] Possible compositions of buildings that the centerpiece is built with.
+        ### The composition with the proper 'levels' is picked, othwerise - the composition with the lowest difference in `ratios`
+        composition = {
+            ### The name is used in 'attach' below
+            name = value_set[city_centerpiece_composition]
+
+            ### [Mutually exclusive with 'levels' and 'ratios'] Trigger to pick this composition as suitable
+            ### Root - state
+            ## cardinality = 0..1
+            ## replace_scope = { root = state this = state }
+            trigger = single_alias_right[trigger_clause]
+
+            ### [Mutually exclusive with 'trigger' and 'ratios'] Defines for which visual levels this composition is suitable. For example, 'levels = { 1 0 2 }' defines the composition of buildings where:
+            ### 	<building_type_1> has visual level 1 (logic level 1-3 from the example above), no <building_type_2>, and <building_type_3> has visual level 2 (logic level 4-8 from the example above)
+            ## cardinality = 0..1
+            levels = {
+                ## cardinality = 0..inf
+                int
+            }
+
+            ### [Mutually exclusive with 'trigger' and 'levels'] Defines for which level ratios this composition is suitable.
+            ### For example, 'ratios = { 1 2 5 }' defines the ratio 1:2:5 or { 0.125 0.25 0.625 }
+            ## cardinality = 0..1
+            ratios = {
+                ## cardinality = 0..inf
+                int
+            }
+        }
+    }
+
+
+    ### [Can be repeated] Defines which entity (if any) to attach to which locator
+    ## cardinality = 0..inf
+    attach = {
+        ### [Optional] The variants are attached to the locator if specified as 'locator' or to the city center otherwise
+        locator = value[city_centerpiece_locator]
+
+        ### [Can be repeated]
+        ## cardinality = 0..inf
+        variant = {
+            ### [Mutually exclusive with 'is_power_bloc_statue'] Name of the entity
+            ## cardinality = 0..1
+            entity = <entity>
+
+            ### [Mutually exclusive with 'entity'] If it's a PB statue then it will be assembled with the statue description from the state's power bloc
+            ## cardinality = 0..1
+            is_power_bloc_statue = bool
+
+            ### [Optional] Which building type this variant represents. It's used to map game state buildings to entities and then send data to shaders
+            ## cardinality = 0..1
+            building_type = <building>
+
+            ### [Optional] The list of possible compositions that this variant is spawned for. A variant without compositions is always spawned
+            ## cardinality = 0..1
+            compositions = {
+                ## cardinality = 0..inf
+                locator = value[city_centerpiece_composition]
+            }
+
+            ### [Can be repeated] Defines which entity (if any) to attach to this entity
+            ## cardinality = 0..inf
+            attach = {
+                ### [Optional] The variants are attached to the locator if specified as 'locator' or to the city center otherwise
+                locator = value[city_centerpiece_locator]
+            }
+        }
+    }
+
+    grid_size = {
+        ## cardinality = 2..2
+        int
+    }
+}

--- a/config/gfx/map/city_data/city_vfx.cwt
+++ b/config/gfx/map/city_data/city_vfx.cwt
@@ -1,0 +1,17 @@
+types = {
+    type[city_vfx] = {
+        path = "gfx/map/city_data/city_vfx"
+        path_extension = .txt
+    }
+}
+
+## replace_scope = { root = state this = state }
+city_vfx = {
+    ### entity type scripted in an .asset file
+    entity = <entity>
+
+    ### visible trigger in a state scope that defines visual effect show condition
+    ### in case if visible trigger became false entity will finish latest state and get destroyed
+    ### !IMPORTANT! Keep visible trigger simple it is called for every vfx for every city in view each frame
+    visible = single_alias_right[trigger_clause]
+}

--- a/config/gfx/map/flagship_ornaments.cwt
+++ b/config/gfx/map/flagship_ornaments.cwt
@@ -1,0 +1,10 @@
+types = {
+    type[flagship_ornament] = {
+        path = "gfx/map/flagship_ornaments"
+        path_extension = .txt
+    }
+}
+
+flagship_ornament = {
+    entity = <entity>
+}

--- a/config/gfx/map/fleet_dioramas.cwt
+++ b/config/gfx/map/fleet_dioramas.cwt
@@ -1,0 +1,70 @@
+types = {
+    type[fleet_diorama] = {
+        path = "gfx/map/fleet_dioramas"
+        path_extension = .txt
+    }
+}
+
+fleet_diorama = {
+    group = enum[fleet_diorama_group]
+
+    ### Unit composition is checked when picking a diorama for a certain military formation
+    ### The closer the composition of the formation corresponds to the percentage, the higher the chance of choosing this diorama
+    composition = {
+        ## cardinality = 1..inf
+        <ship_group> = int
+    }
+
+    ### [Default = 0] Defines a distance value which is used differently for groups:
+    ### fleet: each locator position vector is multiplied by this when positioning entities. The higher the value is, the further entities are from the center point
+    ### battle_side: distance between the center points of one side diorama and the sea province
+    ### blockade: distance between the center points of the blockade diorama and the port city
+    ## cardinality = 0..1
+    distance = int
+
+    ### [Default = 0] For fleet group - defines the maximum offset up to which entities can be randomly positioned
+    ## cardinality = 0..1
+    random_offset = float
+
+    ### Define all locators for the different assets
+    ## cardinality = 1..inf
+    locator = {
+        name = value_set[fleet_diorama_locator]
+
+        position = {
+            ## cardinality = 3..3
+            float
+        }
+
+        rotation = {
+            ## cardinality = 3..3
+            float
+        }
+
+        ## cardinality = 0..1
+        bezier = {
+            ## cardinality = 4..4
+            float
+        }
+
+        scale = float
+    }
+
+    ### Attach all the correct units to locators
+    ## cardinality = 1..inf
+    attach = {
+        locator = value[fleet_diorama_locator]
+
+        ## cardinality = 0..1
+        entity = <entity>
+
+        ## cardinality = 0..1
+        group = <ship_group>
+
+        ## cardinality = 0..1
+        is_visible = single_alias_right[trigger_clause]
+
+        ## cardinality = 0..1
+        main = bool
+    }
+}

--- a/config/gfx/map/fleet_entities.cwt
+++ b/config/gfx/map/fleet_entities.cwt
@@ -1,0 +1,139 @@
+types = {
+    type[fleet_entity] = {
+        path = "gfx/map/fleet_entities"
+        path_extension = .txt
+    }
+}
+
+## replace_scope = { root = country this = country }
+fleet_entity = {
+    ### The ship type which the current graphics is for
+    ship_type = <ship_type>
+
+    ### [Default = yes] Sets this graphics as default for the ship type. If yes, 'trigger' is ignored
+    ## cardinality = 0..1
+    default = bool
+
+    ### [Optional] If this graphics is not default (custom skin), allow the player to select it if trigger is evaluated to true
+    ### root - country
+    ## cardinality = 0..1
+    trigger = single_alias_right[trigger_clause]
+
+    ### [Default = none] Sets visuals for the 'fire' state
+    ## cardinality = 0..1
+    weapon_type = enum[fleet_entity_weapon_type]
+
+    ### [Default = 0.0] Interval between salvos if there are multiple attachments with 'fire' state
+    ## cardinality = 0..1
+    weapon_fire_interval = float
+
+    ### [Default = wood] Sets visuals for the damage taken state. Steel vs Cannons -> damage_weak
+    ## cardinality = 0..1
+    hull_type = enum[fleet_entity_hull_type]
+
+    ### [Default = 1.0] Multiplier for idle/move animation amplitude factor (roll, pitch, heave oscillation).
+    ### Wooden ships typically have higher values (e.g. 1.0), steel ships are more stable (e.g. 0.7)
+    ## cardinality = 0..1
+    motion_intensity = float
+
+    ### [Default = NGraphics::NNavy::SHIP_LENGTH_DEFAULT] Length of the ship entity, used for calculating spacing between ships in route graphics
+    ## cardinality = 0..1
+    length = float
+
+    ### The base ship entity to which modification entities are attached via its locators
+    entity = <entity>
+
+    ### [Can be repeated] VFX entity with optional attachment to a locator
+    ## cardinality = 0..inf
+    vfx_entity = {
+        entity = <entity>
+
+        ### [Default = no] Whether to attach the entity to the base ship entity
+        ## cardinality = 0..1
+        attach = bool
+
+        ### [Optional] Locator name. First checked in 'locator' blocks, then in the base ship entity's model locators
+        ## cardinality = 0..1
+        locator = value[fleet_entity_locator]
+    }
+
+    ### Positions of damage decals
+    damage_decal_positions = {
+        ## cardinality = 4..4
+        {
+            ## cardinality = 4..4
+            float
+        }
+    }
+
+    ### [Can be repeated] [Optional] Declares a named modification to be used by attachments
+    ## cardinality = 0..inf
+    modification = {
+        ### Unique name, is used by attachments
+        name = value_set[fleet_entity_modification]
+
+        ### Related ship modification slot (armor/guns/propulsion/range)
+        slot_type = enum[fleet_entity_modification_slot_type]
+
+        ### [Can be repeated] Entities for each level of ship modification for the slot type (light/medium/high)
+        ### The number of entities must be equal to the number of modification levels in the slot
+        ## cardinality = 0..inf
+        entity = <entity>
+    }
+
+    ### Define all locators for the different assets
+    ## cardinality = 0..inf
+    locator = {
+        name = value_set[fleet_entity_locator]
+
+        position = {
+            ## cardinality = 3..3
+            float
+        }
+
+        rotation = {
+            ## cardinality = 3..3
+            float
+        }
+
+        ## cardinality = 0..1
+        bezier = {
+            ## cardinality = 4..4
+            float
+        }
+
+        scale = float
+    }
+
+    ### [Can be repeated] Defines which entity (if any) to attach to which locator
+    ## cardinality = 0..inf
+    attach = {
+        ### Locator's name in the base entity
+        locator = value[fleet_entity_locator]
+
+        ### Related ship modification slot (armor/guns/propulsion/range)
+        slot_type = enum[fleet_entity_modification_slot_type]
+
+        ### Modifications for each level of ship modification for the slot type (light/medium/high)
+        ### The number of entities must be equal to the number of modification levels in the slot
+        ### If no 'name' and 'entity' is provided, nothing is attached
+        ## cardinality = 0..inf
+        modification = {
+            ### [Mutually exclusive with 'entity'] [Optional] Name of a modification specified above
+            ## cardinality = 0..1
+            name = value[fleet_entity_modification]
+
+            ### [Mutually exclusive with 'name'] [Optional] Directly specified entity
+            ## cardinality = 0..1
+            entity = <entity>
+
+            ### [Default = no] If the modification entity is purely static without the need to change states
+            ## cardinality = 0..1
+            disabled = bool
+
+            ### [Optional] If set then 'combat' state will engage the entity - rotate yaw to this angle
+            ## cardinality = 0..1
+            fire_angle = int
+        }
+    }
+}

--- a/config/gfx/map/front_entities.cwt
+++ b/config/gfx/map/front_entities.cwt
@@ -1,0 +1,22 @@
+types = {
+    type[front_entity] = {
+        path = "gfx/map/front_entities"
+        path_extension = .txt
+    }
+}
+
+## replace_scope = { root = country this = country }
+front_entity = {
+    ### The asset to show
+    entity = <entity>
+
+    ### Group is used in diorama script to determine which entities to pick the entity from for each diorama locator
+    group = value_set[front_entity_group]
+
+    ### Trigger to check if the current entity is valid to show in the diorama
+    ### root - country of the unit
+    ### scope:country - country of the unit (same as root)
+    ### scope:culture - culture of the unit
+    ### scope:combat_unit_type - combat unit type
+    trigger = single_alias_right[trigger_clause]
+}

--- a/config/gfx/map/power_block_statues/accessories.cwt
+++ b/config/gfx/map/power_block_statues/accessories.cwt
@@ -1,0 +1,13 @@
+types = {
+    type[power_bloc_statue_accessory] = {
+        path = "gfx/map/power_block_statues/accessories"
+        path_extension = .txt
+        localisation = {
+            name = $
+        }
+    }
+}
+
+power_bloc_statue_accessory = {
+    entity = <entity>
+}

--- a/config/gfx/map/power_block_statues/heroes.cwt
+++ b/config/gfx/map/power_block_statues/heroes.cwt
@@ -1,0 +1,49 @@
+types = {
+    type[power_bloc_statue_hero] = {
+        path = "gfx/map/power_block_statues/heroes"
+        path_extension = .txt
+        localisation = {
+            name = $
+        }
+    }
+}
+
+power_bloc_statue_hero = {
+    entity = <entity>
+
+    ### This statue piece can be used by AI for random generation for those identities
+    ## cardinality = 0..1
+    default_choice_for_identities = {
+        ## cardinality = 0..inf
+        <power_bloc_identity>
+    }
+
+    ### Attachments
+    ## cardinality = 0..inf
+    attach = {
+        ### Locator name should be the same as attachment points in the mesh
+        locator = value_set[power_bloc_statue_hero_locator]
+
+        ## cardinality = 0..inf
+        accessory = <power_bloc_statue_accessory>
+
+        ### In case we need to specify the locator transform for specific accessory on the hero
+        ## cardinality = 0..inf
+        accessory = {
+            name = <power_bloc_statue_accessory>
+            locator = {
+                position = {
+                    ## cardinality = 3..3
+                    float
+                }
+
+                rotation = {
+                    ## cardinality = 3..3
+                    float
+                }
+
+                scale = float
+            }
+        }
+    }
+}

--- a/config/gfx/map/power_block_statues/pedestals.cwt
+++ b/config/gfx/map/power_block_statues/pedestals.cwt
@@ -1,0 +1,22 @@
+types = {
+    type[power_bloc_statue_pedestal] = {
+        path = "gfx/map/power_block_statues/pedestals"
+        path_extension = .txt
+        localisation = {
+            name = $
+        }
+    }
+}
+
+power_bloc_statue_pedestal = {
+    entity = <entity>
+
+    ### This statue piece can be used by AI for random generation for those identities
+    ## cardinality = 0..1
+    default_choice_for_identities = {
+        ## cardinality = 0..inf
+        <power_bloc_identity>
+    }
+
+    hero_locator = value[power_bloc_statue_hero_locator]
+}

--- a/config/links.cwt
+++ b/config/links.cwt
@@ -1116,6 +1116,7 @@ links = {
 		input_scopes = state
 		output_scope = building
 		from_data = yes
+		from_argument = yes
 		data_source = <building>
 		prefix = b:
 	}


### PR DESCRIPTION
# CWT Config Release
CWT configs are used by [CWTools](https://marketplace.visualstudio.com/items?itemName=tboby.cwtools-vscode) for Visual Studio Code and [Paradox Language Support](https://plugins.jetbrains.com/plugin/16825-paradox-language-support) (PLS) for IntelliJ.
## New Mappings
- Added mappings for `gfx/map/air_graphics`
- Added mappings for `gfx/map/army_dioramas`
- Added mappings for `gfx/map/building_config`
- Added mappings for `gfx/map/flagship_ornaments`
- Added mappings for `gfx/map/fleet_dioramas`
- Added mappings for `gfx/map/fleet_entities`
- Added mappings for `gfx/map/front_entities`
- Added mappings for `gfx/map/city_data/city_building_vfx`
- Added mappings for `gfx/map/city_data/city_centerpiece`
- Added mappings for `gfx/map/city_data/city_vfx`
- Added mappings for `gfx/map/borders/front_graphics`
- Added mappings for `gfx/map/power_block_statues/accessories`
- Added mappings for `gfx/map/power_block_statues/heroes`
- Added mappings for `gfx/map/power_block_statues/pedestals`